### PR TITLE
Fix notices and failure of deploy static content

### DIFF
--- a/app/code/Magento/Deploy/Console/Command/DeployStaticContentCommand.php
+++ b/app/code/Magento/Deploy/Console/Command/DeployStaticContentCommand.php
@@ -20,6 +20,7 @@ use Magento\Deploy\Console\Command\DeployStaticOptionsInterface as Options;
 use Magento\Deploy\Model\DeployManager;
 use Magento\Framework\App\Cache;
 use Magento\Framework\App\Cache\Type\Dummy as DummyCache;
+use Magento\Framework\ObjectManager\ConfigInterface;
 
 /**
  * Deploy static content command
@@ -83,6 +84,11 @@ class DeployStaticContentCommand extends Command
     private $appState;
 
     /**
+     * @var \Magento\Framework\ObjectManager\ConfigInterface $config 
+     */
+    protected $config;
+
+    /**
      * Inject dependencies
      *
      * @param ObjectManagerFactory $objectManagerFactory
@@ -93,11 +99,13 @@ class DeployStaticContentCommand extends Command
     public function __construct(
         ObjectManagerFactory $objectManagerFactory,
         Locale $validator,
-        ObjectManagerInterface $objectManager
+        ObjectManagerInterface $objectManager,
+        ConfigInterface $config
     ) {
         $this->objectManagerFactory = $objectManagerFactory;
         $this->validator = $validator;
         $this->objectManager = $objectManager;
+        $this->config = $config;
 
         parent::__construct();
     }
@@ -490,10 +498,17 @@ class DeployStaticContentCommand extends Command
      */
     private function mockCache()
     {
+        $preferences = $this->config->getPreferences();
+        $instanceTypes = $this->config->getVirtualTypes();
+        $arguments = $this->config->getAllArguments();
+
+        //Swap out the cache class and maintain current preferences/instance types/arguments
+        $preferences[Cache::class] = DummyCache::class;
+
         $this->objectManager->configure([
-            'preferences' => [
-                Cache::class => DummyCache::class
-            ]
+            'preferences' => $preferences,
+            'arguments' => $arguments,
+            'instanceTypes' => $instanceTypes
         ]);
     }
 }

--- a/app/code/Magento/Deploy/Console/Command/DeployStaticContentCommand.php
+++ b/app/code/Magento/Deploy/Console/Command/DeployStaticContentCommand.php
@@ -94,6 +94,7 @@ class DeployStaticContentCommand extends Command
      * @param ObjectManagerFactory $objectManagerFactory
      * @param Locale $validator
      * @param ObjectManagerInterface $objectManager
+     * @param ConfigInterface $config
      * @throws \LogicException When the command name is empty
      */
     public function __construct(

--- a/app/code/Magento/Deploy/Console/Command/DeployStaticOptionsInterface.php
+++ b/app/code/Magento/Deploy/Console/Command/DeployStaticOptionsInterface.php
@@ -84,7 +84,7 @@ interface DeployStaticOptionsInterface
     const EXCLUDE_AREA = 'exclude-area';
 
     /**
-     * Jey for jobs option
+     * Key for jobs option
      */
     const JOBS_AMOUNT = 'jobs';
 

--- a/lib/internal/Magento/Framework/App/Test/Unit/ObjectManager/Environment/ConfigTesting.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/ObjectManager/Environment/ConfigTesting.php
@@ -97,6 +97,16 @@ class ConfigTesting implements ConfigInterface
     }
 
     /**
+     * Returns entire arguments keyed by type
+     *
+     * @return array
+     */
+    public function getAllArguments()
+    {
+        return [];
+    }
+
+    /**
      * Extend configuration
      *
      * @param array $configuration

--- a/lib/internal/Magento/Framework/ObjectManager/Config/Compiled.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Config/Compiled.php
@@ -153,4 +153,14 @@ class Compiled implements \Magento\Framework\ObjectManager\ConfigInterface
     {
         return $this->preferences;
     }
+
+    /**
+     * Returns list on preferences
+     *
+     * @return array
+     */
+    public function getAllArguments()
+    {
+        return $this->arguments;
+    }
 }

--- a/lib/internal/Magento/Framework/ObjectManager/Config/Config.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Config/Config.php
@@ -323,4 +323,14 @@ class Config implements \Magento\Framework\ObjectManager\ConfigInterface
     {
         return $this->_preferences;
     }
+
+    /**
+     * Returns list on preferences
+     *
+     * @return array
+     */
+    public function getAllArguments()
+    {
+        return $this->_arguments;
+    }
 }

--- a/lib/internal/Magento/Framework/ObjectManager/ConfigInterface.php
+++ b/lib/internal/Magento/Framework/ObjectManager/ConfigInterface.php
@@ -34,6 +34,13 @@ interface ConfigInterface
     public function getArguments($type);
 
     /**
+     * Returns entire arguments keyed by type
+     *
+     * @return array
+     */
+    public function getAllArguments();
+
+    /**
      * Check whether type is shared
      *
      * @param string $type


### PR DESCRIPTION
(Just popping this here until i'm ready to pop it into the mainline)

**System notes**

The following is run on 
- the current `develop` branch
- on a fresh install of m2
- on OSX
- mode set to `developer`
- PHP 7.0.9

**The Error**

```
bin/magento setup:static-content:deploy -f
Requested languages: en_US
Requested areas: adminhtml, frontend
Requested themes: Magento/backend, Magento/blank, Magento/luma

  [Exception]
  Notice: Undefined index: arguments in /src/mtwo/lib/internal/Magento/Framework/ObjectManager/Config/Compiled.php on line 132
```

**The problem**
I think this issue was introduced with this section of code which adds a fake cache class for static content deployments: [DeployStaticContentCommand.php#L493](https://github.com/convenient/mtwo/blob/7eca94436239585f8f91e981005db2928b77a1d9/app/code/Magento/Deploy/Console/Command/DeployStaticContentCommand.php#L493)

``` php
    private function mockCache()
    {
        $this->objectManager->configure([
            'preferences' => [
                Cache::class => DummyCache::class
            ]
        ]);
    }
```

This calls configure on the object manager which has a constructor like

``` php
    public function __construct($data)
    {
        $this->arguments = $data['arguments'];
        $this->virtualTypes = $data['instanceTypes'];
        $this->preferences = $data['preferences'];
    }
```

see [ObjectManager/Config/Compiled.php#L34](https://github.com/convenient/mtwo/blob/7eca94436239585f8f91e981005db2928b77a1d9/lib/internal/Magento/Framework/ObjectManager/Config/Compiled.php#L34) for more

As the fake cache command only passes in the `preferences` argument we get a notice for `arguments` and we'd get one for `instanceTypes` if it got that far. Even if we suppress notices things still won't work, as we'd be wiping out all the legitimate configuration for the di config. 

**The solution**

I _think_ the solution for this would be to do a selective update of the diConfig so that we're only mocking out the cache class and leaving the remainder untouched. 

To do this I had to expose the entirety of the `arguments` stored in the config. This seems to allow the command to run and do its thing. After a di recompile the world seemed to be working again.

A caveat, this is my first foray into the M2 configuration and DI system, my solution could be totally whack. Feel free to say point me in the correct direction if I'm doing something silly 👍 
